### PR TITLE
Fix APScheduler timezone check env var name

### DIFF
--- a/bot/tz_guard.py
+++ b/bot/tz_guard.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 import os
 
 def ensure_apscheduler_tz_compat() -> None:
-    # Desactiva con APSCHE_TZ_CHECK=0 si ya controlaste el entorno.
-    if os.getenv("APSCHE_TZ_CHECK", "1") not in {"1", "true", "True"}:
+    # Desactiva con APSCHED_TZ_CHECK=0 si ya controlaste el entorno.
+    if os.getenv("APSCHED_TZ_CHECK", "1") not in {"1", "true", "True"}:
         return
 
     import importlib.metadata as m


### PR DESCRIPTION
## Summary
- fix APSched TZ guard environment variable name in `tz_guard`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb6f74810832fb4c66a122aad7924