### PR TITLE
Add async repo.update_fields test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import asyncio
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    if pyfuncitem.get_closest_marker("asyncio"):
+        loop = asyncio.new_event_loop()
+        try:
+            testargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+            loop.run_until_complete(pyfuncitem.obj(**testargs))
+        finally:
+            loop.close()
+        return True
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: mark async tests")

--- a/tests/test_repo_update_fields.py
+++ b/tests/test_repo_update_fields.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root is on sys.path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from bot.db import repo
+
+
+@pytest.mark.asyncio
+async def test_update_fields_creates_and_updates_record(tmp_path):
+    db_path = tmp_path / "test.db"
+    await repo.ensure_schema(str(db_path))
+    chat_id = 123456
+    await repo.update_fields(str(db_path), chat_id, alerts_on=1)
+    chat = await repo.get_chat(str(db_path), chat_id)
+    assert chat is not None
+    assert chat.chat_id == chat_id
+    assert chat.alerts_on == 1


### PR DESCRIPTION
## Summary
- add pytest to verify repo.update_fields creates a new chat and sets fields
- provide local pytest plugin to run async tests without external dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ebc5c57f0832f906da6ce4443bf1e