### PR TITLE
Handle unknown fields in repo.update_fields

### DIFF
--- a/bot/db/repo.py
+++ b/bot/db/repo.py
@@ -93,8 +93,14 @@ def _upsert_chat_sync(db_path: str, st: ChatState) -> None:
 
 def _update_fields_sync(db_path: str, chat_id: int, **fields) -> None:
     allowed = {"coin_id", "symbol_okx", "tp_pct", "sl_pct", "modo", "precision_on", "alerts_on", "dark_mode"}
+    unknown = set(fields) - allowed
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"Unknown field(s): {names}")
+
     payload = {k: v for k, v in fields.items() if k in allowed}
     if not payload:
+        # Nothing to update – return early without touching the database.
         return
 
     # asegurar existencia

--- a/tests/test_repo_update_fields.py
+++ b/tests/test_repo_update_fields.py
@@ -18,3 +18,13 @@ async def test_update_fields_creates_and_updates_record(tmp_path):
     assert chat is not None
     assert chat.chat_id == chat_id
     assert chat.alerts_on == 1
+
+
+@pytest.mark.asyncio
+async def test_update_fields_rejects_unknown_field(tmp_path):
+    """Passing an unknown field should raise a clear error."""
+    db_path = tmp_path / "test.db"
+    await repo.ensure_schema(str(db_path))
+
+    with pytest.raises(ValueError):
+        await repo.update_fields(str(db_path), 1, invalid_field=True)


### PR DESCRIPTION
## Summary
- Validate fields passed to `repo.update_fields` and raise an error for unknown entries
- Add regression test for invalid field handling in `update_fields`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ebea8d350832f99bd8249b6450e50